### PR TITLE
Switch to new jKanban library

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
     <!-- Bootstrap Icons -->
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
     <!-- jKanban CSS for the Kanban board -->
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/jkanban@1.2.0/dist/jkanban.min.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/jkanban@1.3.1/dist/jkanban.min.css">
     <!-- Custom CSS -->
     <link rel="stylesheet" href="style.css">
     <link rel="icon" type="image/x-icon" href="favicon.ico">
@@ -424,7 +424,7 @@
     <!-- SheetJS para Excel -->
     <script src="https://cdn.jsdelivr.net/npm/xlsx@0.18.5/dist/xlsx.full.min.js"></script>
     <!-- jKanban library for Kanban functionality -->
-    <script src="https://cdn.jsdelivr.net/npm/jkanban@1.2.0/dist/jkanban.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/jkanban@1.3.1/dist/jkanban.min.js"></script>
     <!-- Custom App Logic (Module) -->
     <script type="module" src="app.js"></script>
 

--- a/ui.js
+++ b/ui.js
@@ -1,6 +1,6 @@
 import { openPedidoModal, savePedido, deletePedido, returnToPrintStage } from './pedidoModal.js';
 import { handleSearch, setupSearchAutocomplete } from './utils.js';
-import { renderKanban } from './kanban.js';
+import { renderKanban, renderJKanban } from './kanban.js';
 import { renderList } from './listView.js';
 import { currentPedidos } from './firestore.js';
 import { renderGraficosReportes } from './reportesGraficos.js'; // NUEVO
@@ -70,10 +70,12 @@ export function initializeAppEventListeners() {
         tabBtn.addEventListener('shown.bs.tab', (event) => {
             const targetId = event.target.getAttribute('data-bs-target');
             if (targetId === '#tab-pane-kanban-impresion') {
-                renderKanban(currentPedidos || [], { only: 'impresion' });
+                const render = window.useJKanban && renderJKanban ? renderJKanban : renderKanban;
+                render(currentPedidos || [], { only: 'impresion' });
                 document.getElementById('reportes-graficos').style.display = 'none';
             } else if (targetId === '#tab-pane-kanban-complementarias') {
-                renderKanban(currentPedidos || [], { only: 'complementarias' });
+                const render = window.useJKanban && renderJKanban ? renderJKanban : renderKanban;
+                render(currentPedidos || [], { only: 'complementarias' });
                 document.getElementById('reportes-graficos').style.display = 'none';
             } else if (targetId === '#tab-pane-lista') {
                 renderList(currentPedidos || []);
@@ -114,7 +116,8 @@ export function loadMainAppData() {
     listView.innerHTML = '';
 
     // Renderiza el Kanban de impresión por defecto al cargar datos
-    renderKanban(currentPedidos || [], { only: 'impresion' });
+    const defaultRender = window.useJKanban && renderJKanban ? renderJKanban : renderKanban;
+    defaultRender(currentPedidos || [], { only: 'impresion' });
 
     // Oculta los reportes al inicio
     const reportes = document.getElementById('reportes-graficos');
@@ -132,7 +135,8 @@ window.onPedidosDataUpdate = function(pedidos) {
                 kanbanBoard.innerHTML = '<div class="text-center text-muted py-5">No hay pedidos para mostrar.</div>';
             }
         } else {
-            renderKanban(pedidos, { only: 'impresion' });
+            const render = window.useJKanban && renderJKanban ? renderJKanban : renderKanban;
+            render(pedidos, { only: 'impresion' });
         }
     }
 };


### PR DESCRIPTION
## Summary
- upgrade jKanban CDN to v1.3.1
- use `renderJKanban` when `useJKanban` flag is enabled

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840139b2e4c83289b8f1fdd08916c58