### PR TITLE
Improve jKanban display

### DIFF
--- a/style.css
+++ b/style.css
@@ -454,3 +454,34 @@ body {
         height: 250px;
     }
 }
+
+/* jKanban integration styles */
+#kanban-board.kanban-container,
+#kanban-board-complementarias.kanban-container {
+    display: flex;
+    align-items: flex-start;
+    gap: 1rem;
+    overflow-x: auto;
+    padding-bottom: 1rem;
+}
+
+#kanban-board .kanban-board,
+#kanban-board-complementarias .kanban-board {
+    float: none;
+    width: 300px;
+    min-width: 280px;
+    border-radius: 0.7rem;
+    padding: 0.7rem;
+    margin-right: 1rem;
+}
+
+#kanban-board .kanban-title-board,
+#kanban-board-complementarias .kanban-title-board {
+    display: block;
+    text-align: center;
+    background: white;
+    border-radius: 0.5rem;
+    padding: 0.7rem;
+    margin-bottom: 1rem;
+    font-weight: 500;
+}


### PR DESCRIPTION
## Summary
- show full card markup in jKanban columns
- color jKanban columns using existing logic
- add CSS tweaks for jKanban boards

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684015ef655083288a45ee100a158274