### PR TITLE
Fix Kanban board layout

### DIFF
--- a/style.css
+++ b/style.css
@@ -459,8 +459,8 @@ body {
 #kanban-board > .kanban-container,
 #kanban-board-complementarias > .kanban-container {
     display: flex;
-    flex-direction: column;
-    align-items: stretch;
+    flex-direction: row;
+    align-items: flex-start;
     gap: 1rem;
     overflow-x: auto;
     width: 100% !important;
@@ -470,11 +470,12 @@ body {
 #kanban-board .kanban-board,
 #kanban-board-complementarias .kanban-board {
     float: none;
-    flex: 0 0 100%;
-    width: 100% !important;
+    flex: 0 0 300px;
+    width: 300px;
     min-width: 280px;
     border-radius: 0.7rem;
     padding: 0.7rem;
-    margin-bottom: 1rem;
+    margin-right: 1rem;
+    margin-bottom: 0;
 }
 


### PR DESCRIPTION
## Summary
- display jKanban boards horizontally
- make kanban columns fixed width

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840296df8788328b3f8e32fd390face