### PR TITLE
Fix module export in kanban.js

### DIFF
--- a/kanban.js
+++ b/kanban.js
@@ -1300,6 +1300,8 @@ function setContainerPosition(board, container, newTranslate) {
     return clampedTranslate;
 }
 // Exportar funciones necesarias para testing
-module.exports = {
-  getColumnColorByClientes
-};
+if (typeof module !== 'undefined' && typeof module.exports !== 'undefined') {
+    module.exports = {
+        getColumnColorByClientes
+    };
+}


### PR DESCRIPTION
## Summary
- guard CommonJS export to avoid `module is not defined` browser error

## Testing
- `npm test` *(fails: Jest couldn't parse ESM)*

------
https://chatgpt.com/codex/tasks/task_e_68402cf81fc48328a1b5ea6d84750aba