### PR TITLE
Fix kanban drag scrolling

### DIFF
--- a/kanban.js
+++ b/kanban.js
@@ -39,6 +39,7 @@ export function renderJKanban(pedidos, options = {}) {
         }
     });
 
+    const prevScroll = boardElement.scrollLeft;
     boardElement.innerHTML = '';
     const kanban = new window.jKanban({
         element: boardId,
@@ -52,6 +53,11 @@ export function renderJKanban(pedidos, options = {}) {
             const stage = target.parentElement.getAttribute('data-id');
             if (id && stage) updatePedido(window.db, id, { etapaActual: stage });
         }
+    });
+
+    // Restaurar la posición del scroll después de renderizar
+    requestAnimationFrame(() => {
+        boardElement.scrollLeft = prevScroll;
     });
 
     // Allow horizontal drag scrolling on the board container

--- a/style.css
+++ b/style.css
@@ -463,7 +463,8 @@ body {
     align-items: flex-start;
     gap: 1rem;
     overflow-x: auto;
-    width: 100% !important;
+    /* Ajustar el ancho al contenido para habilitar el scroll horizontal */
+    width: max-content;
     padding: 1rem 0.5rem;
 }
 


### PR DESCRIPTION
## Summary
- allow jKanban container to size according to content so horizontal scrolling works
- keep the kanban scroll position when refreshing the board

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68402ee4486c8328b1f99d3b59224aef