### PR TITLE
Fix kanban drag scrolling

### DIFF
--- a/kanban.js
+++ b/kanban.js
@@ -3,6 +3,17 @@ import { etapasImpresion, etapasComplementarias, currentPedidos } from './firest
 import { openPedidoModal, completeStage } from './pedidoModal.js';
 import { updatePedido } from './firestore.js';
 
+// Mantiene la posición de scroll por tablero
+const boardScrollPositions = {};
+
+function trackBoardScroll(element) {
+    if (!element || element._trackScrollAttached) return;
+    element.addEventListener('scroll', () => {
+        boardScrollPositions[element.id] = element.scrollLeft;
+    });
+    element._trackScrollAttached = true;
+}
+
 // New: simple Kanban rendering using the jKanban library
 export function renderJKanban(pedidos, options = {}) {
     const boardId = options.only === 'complementarias' ? '#kanban-board-complementarias' : '#kanban-board';
@@ -39,6 +50,9 @@ export function renderJKanban(pedidos, options = {}) {
         }
     });
 
+    boardElement.classList.add('jkanban-active');
+    const prevScroll = boardScrollPositions[boardElement.id] ?? boardElement.scrollLeft;
+    boardScrollPositions[boardElement.id] = prevScroll;
     boardElement.innerHTML = '';
     const kanban = new window.jKanban({
         element: boardId,
@@ -50,9 +64,21 @@ export function renderJKanban(pedidos, options = {}) {
         dropEl: (el, target) => {
             const id = el.getAttribute('data-eid');
             const stage = target.parentElement.getAttribute('data-id');
+            const scrollBefore = boardElement.scrollLeft;
+            boardScrollPositions[boardElement.id] = scrollBefore;
             if (id && stage) updatePedido(window.db, id, { etapaActual: stage });
+            requestAnimationFrame(() => {
+                boardElement.scrollLeft = scrollBefore;
+            });
         }
     });
+
+    // Restaurar la posición del scroll después de renderizar
+    requestAnimationFrame(() => {
+        boardElement.scrollLeft = prevScroll;
+    });
+
+    trackBoardScroll(boardElement);
 
     // Allow horizontal drag scrolling on the board container
     enableKanbanDragToScroll(boardElement);
@@ -300,6 +326,9 @@ export function renderKanban(pedidos, options = {}) {
     // --- Guardar translateX de cada grupo antes de limpiar ---
     let mainBoard = document.getElementById('kanban-board');
     let complementaryBoard = document.getElementById('kanban-board-complementarias');
+
+    if (mainBoard) mainBoard.classList.remove('jkanban-active');
+    if (complementaryBoard) complementaryBoard.classList.remove('jkanban-active');
 
     // NUEVO: Ajustar cualquier transformación existente que esté fuera de límites
     function fixExcessiveTranslates() {

--- a/style.css
+++ b/style.css
@@ -48,6 +48,19 @@ body {
     touch-action: pan-y; /* Permitir scroll táctil horizontal */
 }
 
+/* Ajustes cuando se usa jKanban */
+#kanban-board.jkanban-active,
+#kanban-board-complementarias.jkanban-active {
+    display: block;
+    gap: 0;
+    padding-bottom: 1rem;
+}
+
+#kanban-board.jkanban-active > .kanban-container,
+#kanban-board-complementarias.jkanban-active > .kanban-container {
+    display: block;
+}
+
 #kanban-board.drag-scroll-active,
 #kanban-board-complementarias.drag-scroll-active {
     cursor: grabbing !important;
@@ -458,12 +471,10 @@ body {
 /* jKanban integration styles */
 #kanban-board > .kanban-container,
 #kanban-board-complementarias > .kanban-container {
-    display: flex;
-    flex-direction: row;
-    align-items: flex-start;
-    gap: 1rem;
+    display: block;
     overflow-x: auto;
-    width: 100% !important;
+    /* Ajustar el ancho al contenido para habilitar el scroll horizontal */
+    width: max-content;
     padding: 1rem 0.5rem;
 }
 


### PR DESCRIPTION
## Summary
- keep kanban scroll position when rerendering
- adjust styles when using jKanban so columns don't wrap
- track scroll positions per board

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68402ee4486c8328b1f99d3b59224aef