### PR TITLE
Add React dependencies and Jest setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
-# productioncontrol
+# Production Control
+
+Este proyecto implementa un tablero Kanban sincronizado con Firebase para gestionar pedidos.
+
+## Instalación
+
+```bash
+npm install
+```
+
+## Comandos
+
+- `npm start` inicia un servidor de desarrollo y abre la aplicación en el navegador.
+- `npm run build` ejecuta el paso de construcción (actualmente no implementado).
+- `npm test` lanza las pruebas con Jest.
+
+## Dependencias Principales
+
+- **React** y **React DOM** para interfaces de usuario.
+- **Jest** para pruebas automatizadas.

--- a/kanban.js
+++ b/kanban.js
@@ -2,6 +2,7 @@
 import { etapasImpresion, etapasComplementarias, currentPedidos } from './firestore.js'; // O ajusta según donde declares estas variables
 import { openPedidoModal, completeStage } from './pedidoModal.js';
 import { updatePedido } from './firestore.js';
+import { getColumnColorByClientes, stringToColor } from './kanbanUtils.js';
 
 // Mantiene la posición de scroll por tablero
 const boardScrollPositions = {};
@@ -559,44 +560,6 @@ function createKanbanGroup(groupTitle, etapasInGroup, allPedidos) {
 }
 
 // NUEVO: color de columna por cliente más frecuente o primero
-function getColumnColorByClientes(pedidosInEtapa) {
-    if (!pedidosInEtapa || pedidosInEtapa.length === 0) {
-        // Color neutro si no hay pedidos
-        return 'hsl(210, 20%, 97%)';
-    }
-    // Cuenta ocurrencias de cada cliente
-    const counts = {};
-    pedidosInEtapa.forEach(p => {
-        const cliente = p.cliente || '';
-        counts[cliente] = (counts[cliente] || 0) + 1;
-    });
-    // Encuentra el cliente más frecuente
-    let maxCliente = '';
-    let maxCount = 0;
-    Object.entries(counts).forEach(([cliente, count]) => {
-        if (count > maxCount) {
-            maxCount = count;
-            maxCliente = cliente;
-        }
-    });
-    // Si todos son diferentes (maxCount === 1), usa el primero
-    const clienteColor = maxCount === 1
-        ? pedidosInEtapa[0].cliente || ''
-        : maxCliente;
-    // Si no hay cliente, color neutro
-    if (!clienteColor) return 'hsl(210, 20%, 97%)';
-    return stringToColor(clienteColor, 90, 96); // pastel más suave
-}
-
-// Modifica stringToColor para aceptar saturación/luz
-function stringToColor(str, s = 60, l = 80) {
-    let hash = 0;
-    for (let i = 0; i < str.length; i++) {
-        hash = str.charCodeAt(i) + ((hash << 5) - hash);
-    }
-    const h = Math.abs(hash) % 360;
-    return `hsl(${h}, ${s}%, ${l}%)`;
-}
 
 function etapaColumnColor(etapa) {
     // Genera un color pastel único por etapa
@@ -1328,8 +1291,3 @@ function setContainerPosition(board, container, newTranslate) {
     return clampedTranslate;
 }
 // Exportar funciones necesarias para testing
-if (typeof module !== 'undefined' && typeof module.exports !== 'undefined') {
-    module.exports = {
-        getColumnColorByClientes
-    };
-}

--- a/kanbanUtils.js
+++ b/kanbanUtils.js
@@ -1,0 +1,35 @@
+export function getColumnColorByClientes(pedidosInEtapa) {
+  if (!pedidosInEtapa || pedidosInEtapa.length === 0) {
+    return 'hsl(210, 20%, 97%)';
+  }
+
+  const counts = {};
+  pedidosInEtapa.forEach(p => {
+    const cliente = p.cliente || '';
+    counts[cliente] = (counts[cliente] || 0) + 1;
+  });
+
+  let maxCliente = '';
+  let maxCount = 0;
+  Object.entries(counts).forEach(([cliente, count]) => {
+    if (count > maxCount) {
+      maxCount = count;
+      maxCliente = cliente;
+    }
+  });
+
+  const clienteColor = maxCount === 1
+    ? pedidosInEtapa[0].cliente || ''
+    : maxCliente;
+  if (!clienteColor) return 'hsl(210, 20%, 97%)';
+  return stringToColor(clienteColor, 90, 96);
+}
+
+export function stringToColor(str, s = 60, l = 80) {
+  let hash = 0;
+  for (let i = 0; i < str.length; i++) {
+    hash = str.charCodeAt(i) + ((hash << 5) - hash);
+  }
+  const h = Math.abs(hash) % 360;
+  return `hsl(${h}, ${s}%, ${l}%)`;
+}

--- a/package.json
+++ b/package.json
@@ -4,10 +4,20 @@
   "description": "",
   "main": "app.js",
   "scripts": {
-  "test": "jest"
+    "start": "http-server -o",
+    "build": "echo 'No build step defined'",
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
-  "type": "commonjs"
+  "type": "module",
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "jest": "^29.6.1",
+    "http-server": "^14.1.1"
+  }
 }

--- a/test/kanban.test.js
+++ b/test/kanban.test.js
@@ -1,19 +1,19 @@
-const { getColumnColorByClientes } = require('../kanban');
+import { getColumnColorByClientes, stringToColor } from '../kanbanUtils.js';
 
 describe('getColumnColorByClientes', () => {
-  test('debe retornar verde si todos los pedidos son del mismo cliente', () => {
+  test('debe retornar el color del cliente cuando todos son iguales', () => {
     const pedidos = [
       { cliente: 'Cliente A' },
       { cliente: 'Cliente A' }
     ];
-    expect(getColumnColorByClientes(pedidos)).toBe('lightgreen');
+    expect(getColumnColorByClientes(pedidos)).toBe(stringToColor('Cliente A', 90, 96));
   });
 
-  test('debe retornar gris si hay múltiples clientes', () => {
+  test('debe retornar el color del cliente más frecuente o el primero', () => {
     const pedidos = [
       { cliente: 'Cliente A' },
       { cliente: 'Cliente B' }
     ];
-    expect(getColumnColorByClientes(pedidos)).toBe('lightgray');
+    expect(getColumnColorByClientes(pedidos)).toBe(stringToColor('Cliente A', 90, 96));
   });
 });


### PR DESCRIPTION
## Summary
- add React and Jest dependencies
- expose kanban utilities separately for easier testing
- update tests to use new utilities
- document new npm scripts in README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686e31f3a7c083288bde7a04509618c9